### PR TITLE
DM-42636: Add empty pytest config section

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,5 @@ max-line-length = 110
 max-doc-length = 79
 ignore = W503, E203, N802, N803, N806, N812, N815, N816
 exclude = __init__.py
+
+[tool:pytest]


### PR DESCRIPTION
This is needed to stop pytest from searching all the parent directories looking for test configurations.